### PR TITLE
fix - request/response not initalized in construct

### DIFF
--- a/src/Exceptions/MailerLiteHttpException.php
+++ b/src/Exceptions/MailerLiteHttpException.php
@@ -23,6 +23,9 @@ class MailerLiteHttpException extends MailerLiteException implements RequestExce
             $response->getReasonPhrase()
         );
 
+        $this->request = $request;
+        $this->response = $response;
+
         parent::__construct($message, $response->getStatusCode());
     }
 


### PR DESCRIPTION
fix - **$response must not be accessed before initialization in MailerLiteHttpException**