### PR TITLE
Support psr/http-message:^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,14 @@
         "php-http/discovery": "^1.9",
         "php-http/httplug": "^2.1",
         "psr/http-client-implementation": "^1.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.15 || ^8.4 || ^9.0",
         "php-http/mock-client": "^1.0",
         "php-http/message": "^1.0",
         "mockery/mockery": "^0.9.4",
-        "guzzlehttp/psr7": "^1.5.2",
+        "guzzlehttp/psr7": "^2.6.1",
         "http-interop/http-factory-guzzle": "^1.0",
         "php-http/guzzle7-adapter": "^0.1",
         "friendsofphp/php-cs-fixer": "^2.18",
@@ -58,5 +58,10 @@
         "format": [
             "@php vendor/bin/php-cs-fixer fix --verbose --diff"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/src/Common/HttpLayer.php
+++ b/src/Common/HttpLayer.php
@@ -132,16 +132,12 @@ class HttpLayer
         $contentType = $response->hasHeader('Content-Type') ?
             reset($contentTypes) : null;
 
-        $body = '';
-
-        if ($response->getBody()) {
-            switch ($contentType) {
-                case 'application/json':
-                    $body = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
-                    break;
-                default:
-                    $body = $response->getBody()->getContents();
-            }
+        switch ($contentType) {
+            case 'application/json':
+                $body = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+                break;
+            default:
+                $body = $response->getBody()->getContents();
         }
 
         return [


### PR DESCRIPTION
Also, bumps dev dependency on `guzzlehttp/psr7` so that `psr/http-message:^2` can be installed.

I've listed `php-http/discovery` as an allowed plugin - this should help make sure that CI proceeds as it should and won't affect consumers of this package.

In order to keep PHPStan happy, I've removed a useless conditional. `Psr\HttpResponse::getBody()` _always_ returns a stream.

Closes #11