### PR TITLE
Feature/mld 42879/fix wrong url in campaign report

### DIFF
--- a/src/Endpoints/Campaign.php
+++ b/src/Endpoints/Campaign.php
@@ -96,7 +96,7 @@ class Campaign extends AbstractEndpoint
     public function getSubscriberActivity(string $campaignId, array $params): array
     {
         return $this->httpLayer->post(
-            $this->buildUri("{$this->endpoint}/{$campaignId}/subscriber-activity"),
+            $this->buildUri("{$this->endpoint}/{$campaignId}/reports/subscriber-activity"),
             $params
         );
     }

--- a/tests/Endpoints/CampaignTest.php
+++ b/tests/Endpoints/CampaignTest.php
@@ -108,6 +108,6 @@ class CampaignTest extends TestCase
         $request = $this->client->getLastRequest();
 
         self::assertEquals('POST', $request->getMethod());
-        self::assertEquals("/api/campaigns/{$this->campaignId}/subscriber-activity", $request->getUri()->getPath());
+        self::assertEquals("/api/campaigns/{$this->campaignId}/reports/subscriber-activity", $request->getUri()->getPath());
     }
 }


### PR DESCRIPTION
This pull request introduces changes in campaign subscribers activity reports.

## Changes
- Updated getSubscriberActivity endpoint to correct one